### PR TITLE
new feature: should omit blanks for the field name in 'rules'

### DIFF
--- a/jquery/jquery.rsv-2.5.1.js
+++ b/jquery/jquery.rsv-2.5.1.js
@@ -125,7 +125,8 @@
 
 
       var requirement = row[0];
-      var fieldName   = row[1];
+      // for the case of field name wrapped by blank(s): "required, first_name ,Please enter your first name."
+      var fieldName   = $.trim(row[1]);
       var fieldName2, fieldName3, errorMessage, lengthRequirements, date_flag;
 
 

--- a/jquery/test_case_should_omit_blanks_for_the_field_name_in_rules.html
+++ b/jquery/test_case_should_omit_blanks_for_the_field_name_in_rules.html
@@ -1,0 +1,85 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Examples -- Really Simple Validation for jQuery .</title>
+
+    <meta name="keyword" content=""/>
+    <meta name="description" content=""/>
+    <meta name="copyright" content="Copyright 1994-2010 Motorola, Inc. All Rights Reserved."/>
+    <link rel="stylesheet" href="style.css" type="text/css" />
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
+    <script src="jquery.rsv-2.5.1.js" type="text/javascript"></script>
+<script type="text/javascript">
+
+  // a custom onComplete handler to prevent form submits for the demo
+  function myOnComplete()
+  {
+    alert("The form validates! (normally, it would submit the form here).");
+    return false;
+  }
+
+    $(document).ready(function() {
+    $("#demo_form5").RSV({
+      onCompleteHandler: myOnComplete,
+      errorFieldClass: "errorFieldDemo5",
+      displayType: "display-html",
+      errorHTMLItemBullet: "&#8212; ",
+        rules: [
+            "required, first_name ,Please enter your first name."
+        ]
+    });
+}); </script>
+
+    <style type="text/css">
+    /* these are the various classes used to style the demo error fields */
+    .errorField {
+      background-color: #990000;
+      color: white;
+    }
+    .errorFieldDemo2 {
+      background-color: #ffffcc;
+      color: #990000;
+    }
+    .errorFieldDemo5 {
+      background-color: #ffffcc;
+      border: 1px solid #aa0000;
+      color: #aa0000;
+    }
+    .errorFieldDemo6 {
+      background-color: green;
+      color: #yellow;
+    }
+    </style>
+  </head>
+  <body>
+<p class="subtitle blue">A test page derived from #5: Display type "display-html"</p>
+
+    <p>
+<pre>
+rules: [
+    "required, first_name ,Please enter your first name."
+]
+</pre>
+should not cause an alert of :
+    RSV Error: the field " first_name " doesn't exist! Please check your form and settings.
+    </p>
+
+        <div id="rsvErrors"></div>
+
+    <form action="" method="post" id="demo_form5">
+
+      <table class="demoTable" cellpadding="0" cellspacing="1">
+      <tr>
+        <th width="150">First Name:</th>
+        <td><input type="text" name="first_name" /></td>
+      </tr>
+      </table>
+
+      <p><input type="submit" value="SUBMIT" /></p>
+
+    </form>
+  </body>
+</html>
+

--- a/selenium_scripts/should_omit_blanks_for_the_field_name_in_rules.html
+++ b/selenium_scripts/should_omit_blanks_for_the_field_name_in_rules.html
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="file:///tmp/rsv/" />
+<title>jquery_should_trim_the_field_name_in_declaration_string</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">jquery_should_trim_the_field_name_in_declaration_string</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>jquery/test_case_should_omit_blanks_for_the_field_name_in_rules.html</td>
+	<td></td>
+</tr>
+<!--no input at all-->
+<tr>
+	<td>click</td>
+	<td>css=input[type=&quot;submit&quot;]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyTextPresent</td>
+	<td>Please enter your first name.</td>
+	<td></td>
+</tr>
+<!--let's input all the fields.-->
+<tr>
+	<td>type</td>
+	<td>name=first_name</td>
+	<td>Jim</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=input[type=&quot;submit&quot;]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyAlert</td>
+	<td>glob:*The form validates!*</td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>


### PR DESCRIPTION
There is a very common case that people like using blank keys before typing a comma, e.g.

```
    rules: [
        // here the 'first_name' is wrapped by 2 blanks. 
        "required, first_name ,Please enter your first name."
    ]
```

and this often causes an alert:   

```
RSV Error: the field " first_name " doesn't exist! Please check your form and settings
```

for solving this problem, I added this commit. please review. 
