### PR TITLE
fixed bug: once the form is validated, should hide the previous error message div

### DIFF
--- a/jquery/jquery.rsv-2.5.1.js
+++ b/jquery/jquery.rsv-2.5.1.js
@@ -50,10 +50,19 @@
    */
   $.fn.RSV.validate = function(event)
   {
+
     options = event.data.options;
     var form  = event.data.currForm;
     var rules = options.rules;
     returnHash = [];
+
+    //hide the previous error message if there is in the displayType: 'display-html'.
+    if(options.displayType == "display-html"){
+        $("#"+options.errorTargetElementId).text("").css("display", "none")
+        if(options.errorFieldClass != null ) {
+            $("."+options.errorFieldClass).removeClass(options.errorFieldClass)
+        }
+    }
 
     // loop through rules
     for (var i=0; i<rules.length; i++)

--- a/selenium_scripts/jquery_example5_display_html.html
+++ b/selenium_scripts/jquery_example5_display_html.html
@@ -16,10 +16,20 @@
 	<td>jquery/example_5_display_type_display_html.html</td>
 	<td></td>
 </tr>
+<tr>
+	<td>verifyNotVisible</td>
+	<td>css=#rsvErrors</td>
+	<td></td>
+</tr>
 <!--no input at all-->
 <tr>
 	<td>click</td>
 	<td>css=input[type=&quot;submit&quot;]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyVisible</td>
+	<td>css=#rsvErrors</td>
 	<td></td>
 </tr>
 <tr>
@@ -61,6 +71,16 @@
 <tr>
 	<td>verifyAlert</td>
 	<td>The form validates! (normally, it would submit the form here).</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyTextNotPresent</td>
+	<td>Please fix the following error(s) and resubmit:</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNotVisible</td>
+	<td>css=#rsvErrors</td>
 	<td></td>
 </tr>
 </tbody></table>


### PR DESCRIPTION
Hi Ben,

  when using the displayType='display-html', I am always asked by the end user "why the form is being submitted while the error message still shown there?"  I think the root cause is that RSV hasn't clear the previous error message and error field classes. so I fixed this issue.  

  Please take a look and review.

thanks,
Siwei
